### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/apache-skywalking`
 
-The Paketo Apache SkyWalking Buildpack is a Cloud Native Buildpack that contributes the [Apache SkyWalking][s] Agent and configures it to connect to the service.
+The Paketo Buildpack for Apache SkyWalking is a Cloud Native Buildpack that contributes the [Apache SkyWalking][s] Agent and configures it to connect to the service.
 
 [s]: https://skywalking.apache.org
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/apache-skywalking"
   id = "paketo-buildpacks/apache-skywalking"
   keywords = ["apache-skywalking", "agent", "apm"]
-  name = "Paketo Apache SkyWalking Buildpack"
+  name = "Paketo Buildpack for Apache SkyWalking"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Apache SkyWalking Buildpack' to 'Paketo Buildpack for Apache SkyWalking'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
